### PR TITLE
Fix broken content links and formalize local testing workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,13 +28,13 @@ Before merge, update `CHANGELOG.md` to reflect all user-facing, CI, or policy ch
 
 ## Testing Guidelines
 
-Treat local rendering checks as required for content, navigation, or styling changes:
+Follow [`TESTING.md`](/home/ejh/Repos/Dharma-Siblings/TESTING.md) as the required source of truth for local verification before opening or merging a PR.
 
-- Start the site with `bundle exec jekyll serve --livereload`.
-- Open each primary page (`/`, `/pages/liturgy`, `/pages/video-and-film`, `/pages/artwork`, `/pages/literature`, `/pages/recipes`) and confirm layout, navigation, and media embeds render correctly.
-- Confirm changed pages on both desktop-width and mobile-width viewports.
-
-After visual checks, run `markdownlint`, `yamllint`, and `bundle exec jekyll build` before opening a PR. Run Lychee when link checks are in scope. Use descriptive section headings (`## Practice Resources - Chanting`) so anchor links remain stable. When referencing downloads or images, ensure the file exists under `assets/` and the relative path works locally.
+- Treat manual local rendering checks as mandatory for content, navigation, and styling changes.
+- Treat lint/build checks in `TESTING.md` as required PR gates.
+- Run Lychee when link checks are in scope.
+- Use descriptive section headings (`## Practice Resources - Chanting`) so anchor links remain stable.
+- When referencing downloads or images, ensure the file exists under `assets/` and the relative path works locally.
 
 ## Linting Scope for Config Files
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,10 +14,16 @@ Added
 - `CODEOWNERS` with default repository ownership rule.
 - `SECURITY.md` with vulnerability reporting guidance.
 - Yardstick badge in `README.md` project status section.
+- `TESTING.md` with explicit local rendering checks, required validation commands, and merge-readiness checklist.
 
 Changed
 
 - `AGENTS.md` expanded with explicit lint/test expectations, local rendering checks, and local Yardstick command guidance.
+- `AGENTS.md` testing section now references `TESTING.md` as the required local verification source of truth.
+- `pages/video-and-film.md` broken media links were replaced with working video embeds and verified official channel/center links.
+- `pages/liturgy.md` broken and outdated resource links were refreshed across liturgy, sutra, and study sections.
+- `pages/recipes.md` embedded video URL parameters were updated to a working variant.
+- `TODO.txt` link-repair notes were reorganized for ongoing broken-link triage.
 - `_config.yml` updated to exclude `AGENTS.md` and `CHANGELOG.md` from generated site output and nav/search indexing.
 - `_config.yml` exclusion list expanded so root-level repository docs (`README.md`, `CONTRIBUTING.md`, `SECURITY.md`) are not published as site pages.
 - `_sass/custom/custom.scss` updated to restore visible logo rendering and increase header logo display size.

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,0 +1,85 @@
+# Testing Guide
+
+This file defines the required local testing workflow for Dharma Siblings.
+
+## 1) Prerequisites
+
+- Ruby and Bundler installed.
+- Project dependencies installed with:
+  - `bundle install`
+- Optional lint/link tools:
+  - `npm install -g markdownlint-cli`
+  - `pip install yamllint`
+  - `cargo install lychee` (or your preferred install method)
+
+## 2) Start Local Site
+
+1. Run:
+   - `bundle exec jekyll serve --livereload --trace`
+2. Wait for:
+   - `Server address: http://127.0.0.1:4000`
+3. Keep this terminal running while testing pages.
+
+## 3) Required Manual Rendering Checks
+
+Open these routes in a browser and confirm each page renders without obvious layout/content issues:
+
+- `/`
+- `/pages/liturgy`
+- `/pages/video-and-film`
+- `/pages/artwork`
+- `/pages/literature`
+- `/pages/recipes`
+
+For each changed page, verify:
+
+- Page title and section headings are visible and correct.
+- Left navigation includes expected items and excludes repo-only docs.
+- Images, embeds, and downloads load correctly.
+- Internal links navigate to the expected page/section.
+- External links open the expected destination.
+
+## 4) Viewport Checks
+
+For changed pages, test both:
+
+- Desktop width (about 1280px+)
+- Mobile width (about 390px)
+
+Confirm at both sizes:
+
+- Navigation is usable.
+- Text is readable and not cut off.
+- Media does not overflow containers.
+
+## 5) Required Local Validation Commands
+
+Run these before opening/updating a PR:
+
+1. `bundle exec jekyll build`
+2. `markdownlint "**/*.md"`
+3. `yamllint .`
+4. `jq . renovate.json > /dev/null`
+5. `yardstick -path . -format table`
+
+Run when link updates are part of the change:
+
+1. `lychee --verbose --exclude-mail --timeout 20 "**/*.md"`
+
+## 6) Failure Handling
+
+If a check fails:
+
+- Fix source files (never edit `_site/` directly).
+- Re-run the failed command.
+- Re-run `bundle exec jekyll build` after fixes.
+- Re-check affected pages in the browser.
+
+## 7) Merge Readiness Checklist
+
+Before merge, confirm all are true:
+
+- Manual rendering checks completed for affected pages.
+- Desktop and mobile checks completed.
+- Required validation commands passed.
+- `CHANGELOG.md` updated with user-facing and CI/policy changes.

--- a/TODO.txt
+++ b/TODO.txt
@@ -11,3 +11,14 @@ Additional categories in the navbar? Expanded categories?
 Embed the rest of the videos (embed organization?)
 
 release tags, changelog reqs, protected branch, etc
+
+Broken links by page (format: description of URL: URL)
+
+## pages/video-and-film.md
+Spring, Summer, Fall, Winter, and Spring
+Zen (2009)
+Why Has Bodhi-Dharma Left for the East
+The Mountain Path - Ed Burger link needs to be added
+
+AFTER FIXING THESE LINKS:
+    Find alternatives to Amazon listings, preferring publisher listings

--- a/index.md
+++ b/index.md
@@ -49,8 +49,8 @@ Thank you for helping care for this container.
 
 ## 🔗 Quick Links
 
-- [🎨 Artwork](/pages/artwork)
-- [🎥 Video and Film](/pages/video-and-film)
-- [📚 Literature](/pages/literature)
-- [🪷 Liturgy](/pages/liturgy)
-- [🥗 Recipes](/pages/recipes)
+- [🎨 Artwork]({{ '/pages/artwork' | relative_url }})
+- [🎥 Video and Film]({{ '/pages/video-and-film' | relative_url }})
+- [📚 Literature]({{ '/pages/literature' | relative_url }})
+- [🪷 Liturgy]({{ '/pages/liturgy' | relative_url }})
+- [🥗 Recipes]({{ '/pages/recipes' | relative_url }})

--- a/pages/liturgy.md
+++ b/pages/liturgy.md
@@ -24,36 +24,33 @@ This page is intended for study, memorization, and reverent reflection. 🪷
 
 Texts commonly chanted during service or zazen periods in Sōtō temples and sanghas.
 
-- **Houston Zen Center Liturgy & Chants**  
+- **Houston Zen Center Liturgy & Chants**
   [HZC Liturgy & Chants](https://houstonzen.org/liturgy)
 
-- **Sōtō School Scriptures for Daily Services and Practice**  
+- **Sōtō School Scriptures for Daily Services and Practice**
   [Download PDF – Sōtō Zen Official](https://global.sotozen-net.or.jp/eng/practice/sutra/pdf/Scriptures.pdf)
 
-- **Heart Sutra** (*般若心経 / Hannya Shingyō*)  
-  [English Translation – Huntington Archive](https://huntingtonarchive.org/resources/downloads/sutras/02Prajnaparamita/heartsutra.pdf)  
-  [Japanese Text – Sōtō Zen](https://global.sotozen-net.or.jp/jpn/library/chanting/hannya_shingyo.html)
+- **Heart Sutra** (*般若心経 / Hannya Shingyō*)
+  [English Translation – Huntington Archive](https://huntingtonarchive.org/resources/downloads/sutras/02Prajnaparamita/heartsutra.pdf#G7.1044561)
+  [Japanese Alliterative Text – Sōtō Zen](https://www.sotozen.com/eng/practice/sutra/pdf/04/04.pdf)
 
-- **Universal Gateway Chapter** (*観世音菩薩普門品 / Kanzeon Bosatsu Fumonbon*)  
-  [English Translation – Sōtō Zen](https://global.sotozen-net.or.jp/eng/library/chanting/universal_gateway.html)
+- **Universal Gateway Chapter** (*観世音菩薩普門品 / Kanzeon Bosatsu Fumonbon*)
+  [English Translation – Sōtō Zen](https://www.sotozen.com/eng/practice/sutra/pdf/01/01.pdf#page=2)
 
-- **Song of the Precious Mirror Samadhi** (*宝鏡三昧 / Hōkyō Zanmai*)  
-  [English Translation – Sōtō Zen](https://global.sotozen-net.or.jp/eng/library/chanting/precious_mirror.html)
+- **Song of the Precious Mirror Samadhi** (*宝鏡三昧 / Hōkyō Zanmai*)
+  [English Translation – Sōtō Zen](https://www.sotozen.com/eng/practice/sutra/pdf/01/06.pdf)
 
-- **Harmony of Difference and Equality** (*参同契 / Sandōkai*)  
-  [English Translation – Sōtō Zen](https://global.sotozen-net.or.jp/eng/library/chanting/harmony.html)
+- **Harmony of Difference and Equality** (*参同契 / Sandōkai*)
+  [English Translation – Sōtō Zen](https://www.sotozen.com/eng/practice/sutra/pdf/01/05.pdf)
 
-- **Fukanzazengi** (*普勧坐禅儀*)  
-  [English Translation – Sōtō Zen](https://global.sotozen-net.or.jp/eng/library/chanting/fukanzazengi.html)
+- **Fukanzazengi** (*普勧坐禅儀*)
+  [English Translation – Sōtō Zen](https://www.sotozen.com/eng/practice/sutra/pdf/03/c01.pdf)
 
-- **Zazengi** (*坐禅儀*)  
-  [English Translation – Sōtō Zen](https://global.sotozen-net.or.jp/eng/library/chanting/zazengi.html)
+- **Shushōgi** (*修証義*)
+  [English Translation – Sōtō Zen](https://www.sotozen.com/eng/practice/sutra/pdf/04/25.pdf)
 
-- **Shushōgi** (*修証義*)  
-  [English Translation – Sōtō Zen](https://global.sotozen-net.or.jp/eng/library/chanting/shushogi.html)
-
-- **Bendōwa** (*弁道話*)  
-  [English Translation – Sōtō Zen](https://global.sotozen-net.or.jp/eng/library/chanting/bendowa.html)
+- **Bendōwa** (*弁道話*)
+  [English Translation – Zen Bristol](https://global.sotozen-net.or.jp/eng/library/chanting/bendowa.html)
 
 ---
 
@@ -61,30 +58,30 @@ Texts commonly chanted during service or zazen periods in Sōtō temples and san
 
 A family of Mahāyāna texts exploring emptiness (*śūnyatā*), non-duality, and wisdom practice.
 
-- **100,000-Line Perfection of Wisdom (Śatasāhasrikā)**  
+- **100,000-Line Perfection of Wisdom (Śatasāhasrikā)**
   [Sanskrit Text – Digital Sanskrit Buddhist Canon](http://www.dsbcproject.org/canon-text/content/8/1)
 
-- **25,000-Line Perfection of Wisdom (Pañcaviṃśatisāhasrikā)**  
+- **25,000-Line Perfection of Wisdom (Pañcaviṃśatisāhasrikā)**
   [Sanskrit Text – Digital Sanskrit Buddhist Canon](http://www.dsbcproject.org/canon-text/content/8/2)
 
-- **18,000-Line Perfection of Wisdom (Aṣṭādaśasāhasrikā)**  
+- **18,000-Line Perfection of Wisdom (Aṣṭādaśasāhasrikā)**
   [Sanskrit Text – Digital Sanskrit Buddhist Canon](http://www.dsbcproject.org/canon-text/content/8/3)
 
-- **8,000-Line Perfection of Wisdom (Aṣṭasāhasrikā)**  
+- **8,000-Line Perfection of Wisdom (Aṣṭasāhasrikā)**
   [Full English Translation (PDF)](https://huntingtonarchive.org/resources/downloads/sutras/02Prajnaparamita/Astasahasrika.pdf)
 
-- **700-Line Perfection of Wisdom (Saptaśatikā)**  
+- **700-Line Perfection of Wisdom (Saptaśatikā)**
   [Sanskrit Text – Digital Sanskrit Buddhist Canon](http://www.dsbcproject.org/canon-text/content/8/4)
 
-- **Heart Sutra (Prajñāpāramitā Hṛdaya)**  
-  [English PDF](https://huntingtonarchive.org/resources/downloads/sutras/02Prajnaparamita/heartsutra.pdf)  
+- **Heart Sutra (Prajñāpāramitā Hṛdaya)**
+  [English PDF](https://huntingtonarchive.org/resources/downloads/sutras/02Prajnaparamita/heartsutra.pdf)
   [Japanese Text – Sōtō Zen](https://global.sotozen-net.or.jp/jpn/library/chanting/hannya_shingyo.html)
 
-- **Diamond Sutra (Vajracchedikā Prajñāpāramitā)**  
-  [English PDF](https://www.lifelonglearningcollaborative.org/silkroads/articles/diamond-sutra-translation.pdf)  
+- **Diamond Sutra (Vajracchedikā Prajñāpāramitā)**
+  [English PDF](https://www.lifelonglearningcollaborative.org/silkroads/articles/diamond-sutra-translation.pdf)
   [Chinese Text – CBETA](https://cbetaonline.dila.edu.tw/en/T08n0235_001)
 
-- **Perfection of Wisdom in 150 Lines**  
+- **Perfection of Wisdom in 150 Lines**
   [Sanskrit Text – Digital Sanskrit Buddhist Canon](http://www.dsbcproject.org/canon-text/content/8/5)
 
 ---
@@ -93,16 +90,16 @@ A family of Mahāyāna texts exploring emptiness (*śūnyatā*), non-duality, an
 
 These are not chanted liturgically but have significant impact on Sōtō teachings.
 
-- **Lotus Sutra** (*法華経 / Hokke-kyō*)  
-  [BDK Translation PDF](https://bdkamerica.org/download/1891)  
+- **Lotus Sutra** (*法華経 / Hokke-kyō*)
+  [BDK Translation PDF](https://bdkamerica.org/download/1891)
   [Product Page – BDK America](https://www.bdkamerica.org/product/the-lotus-sutra-revised-second-edition/)
 
-- **Lankavatara Sutra** (*楞伽経*)  
-  [D.T. Suzuki Translation](https://buddhanature.tsadra.org/index.php/Books/The_Laṅkāvatāra_Sūtra_(2003))  
+- **Lankavatara Sutra** (*楞伽経*)
+  [D.T. Suzuki Translation](https://buddhanature.tsadra.org/index.php/Books/The_Laṅkāvatāra_Sūtra_(2003))
   [Red Pine Translation – SMZC](https://www.smzc.org/product-page/lankavatara-sutra-by-red-pine)
 
-- **Brahma Net Sutra** (*梵網経*)  
-  [BDK Translation PDF](https://bdkamerica.org/download/1959)  
+- **Brahma Net Sutra** (*梵網経*)
+  [BDK Translation PDF](https://bdkamerica.org/download/1959)
   [Product Page – BDK America](https://www.bdkamerica.org/product/the-brahmas-net-sutra/)
 
 ---
@@ -115,83 +112,83 @@ Though not sūtras, the following shape our Zen inheritance:
 
 Dōgen’s masterwork, composed between 1231 and 1253, is a cornerstone of Sōtō Zen literature.
 
-- **Sōtō Zen Text Project Translation**  
-  📘 [University of Hawai‘i Press – 8-volume set](https://uhpress.hawaii.edu/title/treasury-of-the-true-dharma-eye-dogens-shobogenzo-eight-volume-set/)  
+- **Sōtō Zen Text Project Translation**
+  📘 [University of Hawai‘i Press – 8-volume set](https://uhpress.hawaii.edu/title/treasury-of-the-true-dharma-eye-dogens-shobogenzo-eight-volume-set/)
   📘 [Stanford HCBSS Project Page](https://buddhiststudies.stanford.edu/news/soto-zen-text-projects-translation-shobogenzo-zhengfayancang-entitled-treasury-true-dharma-eye)
 
-- **Gudo Nishijima & Chodo Cross Translation**  
-  📄 [Authorized Version (HTML)](https://www.shobogenzo.net/index.php/text-1/authorised-version/)  
+- **Gudo Nishijima & Chodo Cross Translation**
+  📄 [Authorized Version (HTML)](https://www.shobogenzo.net/index.php/text-1/authorised-version/)
   📄 [Downloadable eBooks](https://dogensanghas.com/shobogenzo/)
 
-- **Rev. Hubert Nearman Translation**  
-  📄 [Complete PDF – Shasta Abbey](https://www.shastaabbey.org/pdf/shoboAll.pdf)  
+- **Rev. Hubert Nearman Translation**
+  📄 [Complete PDF – Shasta Abbey](https://www.shastaabbey.org/pdf/shoboAll.pdf)
   📄 [Urban Dharma Archive](https://www.urbandharma.org/udharma12/shobo.html)
 
-- **Kazuaki Tanahashi & Peter Levitt Translation**  
-  📘 [Shambhala Publications – Hardcover](https://www.shambhala.com/treasury-of-the-true-dharma-eye-zen-master-dogen-s-shobo-genzo.html)
+- **Kazuaki Tanahashi & Peter Levitt Translation**
+  📘 [Shambhala Publications – Hardcover](https://www.shambhala.com/treasury-of-the-true-dharma-eye-2796.html)
 
-- **Kōsen Nishiyama & John Stevens Translation**  
+- **Kōsen Nishiyama & John Stevens Translation**
   📘 [Goodreads Overview](https://www.goodreads.com/work/editions/475744-master-dogen-s-shobogenzo-book-4)
 
 #### **Shōbōgenzō Zuimonki** (*正法眼蔵随聞記*) – Record of Things Heard
 
 A collection of Dōgen’s informal Dharma talks recorded by his disciple Koun Ejō.
 
-- **Reiho Masunaga Translation**  
+- **Reiho Masunaga Translation**
   📘 [Goodreads – A Primer of Sōtō Zen](https://www.goodreads.com/book/show/1574187.A_Primer_of_Soto_Zen)
 
-- **Shohaku Okumura Translation**  
+- **Shohaku Okumura Translation**
   📘 [Wisdom Publications – Dōgen’s Shōbōgenzō Zuimonki](https://wisdomexperience.org/product/dogens-shobogenzo-zuimonki/)
 
 #### **Shinji Shōbōgenzō** (*真字正法眼蔵*) – The True Dharma Eye 300 Kōans
 
 Dōgen’s kōan collection, compiled in classical style.
 
-- **Gudo Nishijima Translation**  
-  📘 [Windbell Publications](https://www.windbell-publications.com/shinji-shobogenzo)
+- **Gudo Nishijima Translation**
+  📘 [Windbell Publications](https://www.shobogenzo.net/index.php/text-1/authorised-version/)
 
-- **John Daido Loori & Kazuaki Tanahashi Translation**  
-  📘 [Shambhala – The True Dharma Eye](https://www.shambhala.com/the-true-dharma-eye.html)
+- **John Daido Loori & Kazuaki Tanahashi Translation**
+  📘 [Shambhala – The True Dharma Eye](https://www.shambhala.com/the-true-dharma-eye-1590.html)
 
 #### **Record of Dongshan / Tozan Ryōkai** (*洞山良价録*)
 
 Foundational source for the Five Ranks and Mirror Samadhi, central to Sōtō metaphysics.
 
-- **Dongshan’s Five Ranks** (translation & analysis)  
-  📄 [Insight Journal – Thomas Cleary](https://www.dharma.org/dongshan-s-five-ranks/)  
-  📘 [Book – “The Five Ranks” by Ross Bolleter](https://www.wisdompubs.org/book/five-ranks)
+- **Dongshan’s Five Ranks** (translation & analysis)
+  📄 [Insight Journal – Thomas Cleary](https://www.patheos.com/blogs/monkeymind/2022/11/thomas-cleary-on-dongshans-five-ranks.html)
+  📘 [Book – “The Five Ranks” by Ross Bolleter](https://www.abebooks.com/9780861715305/Dongshans-Five-Ranks-Keys-Enlightenment-0861715306/plp)
 
-- **Dongshan’s Record in “Cultivating the Empty Field”**  
-  📘 [Taigen Dan Leighton Translation](https://www.wisdompubs.org/book/cultivating-empty-field)
+- **Dongshan’s Record in “Cultivating the Empty Field”**
+  📘 [Taigen Dan Leighton Translation](https://www.abebooks.com/Cultivating-Empty-Field-Silent-Illumination-Zen/30326203268/bd)
 
 #### **Poetry of Ryōkan, Dōgen, and Han Shan**
 
 Zen poetry offers insight through evocative language and radical intimacy with impermanence.
 
-- **Ryōkan** – *One Robe, One Bowl*  
-  📘 [Amazon – Ryōkan, translated by John Stevens](https://www.amazon.com/One-Robe-Bowl-Ryokan/dp/0804814794)
+- **Ryōkan** – *One Robe, One Bowl*
+  📘 [Shambhala Publications – Ryōkan, translated by John Stevens](https://www.shambhala.com/dewdrops-on-a-lotus-leaf-478.html)
 
-- **Dōgen** – *Moon in a Dewdrop*  
-  📘 [Shambhala – edited by Kazuaki Tanahashi](https://www.shambhala.com/moon-in-a-dewdrop-1067.html)
+- **Dōgen** – *Moon in a Dewdrop*
+  📘 [The Monastery Store – edited by Kazuaki Tanahashi](https://monasterystore.org/products/moon-in-a-dewdrop)
 
-- **Han Shan** – *Cold Mountain Poems*  
-  📘 [Red Pine Translation – Copper Canyon Press](https://www.coppercanyonpress.org/books/the-collected-songs-of-cold-mountain-han-shan/)
+- **Han Shan** – *The Collected Songs of Cold Mountain*
+  📘 [Red Pine Translation – Copper Canyon Press](https://www.coppercanyonpress.org/books/the-collected-songs-of-cold-mountain-by-han-shan-cold-mountain-tr-bill-porter-red-pine/)
 
 #### **Modern Commentaries and Kōan Collections**
 
 While not part of traditional liturgy, these works illuminate practice with contemporary voices.
 
-- **The Book of Serenity (Shōyōroku)**  
-  📘 [Thomas Cleary Translation](https://www.shambhala.com/the-book-of-serenity-3723.html)
+- **The Book of Serenity (Shōyōroku)**
+  📘 [Thomas Cleary Translation](https://monasterystore.org/products/book-of-serenity)
 
-- **The Blue Cliff Record (Hekiganroku)**  
-  📘 [Thomas Cleary Translation](https://www.shambhala.com/blue-cliff-record-3844.html)
+- **The Blue Cliff Record (Hekiganroku)**
+  📘 [Thomas Cleary Translation](https://monasterystore.org/products/blue-cliff-record)
 
-- **Bringing the Sacred to Life** – John Daido Loori on art and practice  
-  📘 [Dharma Communications](https://bookshop.org/p/books/bringing-the-sacred-to-life-john-daido-loori/18313326)
+- **Bringing the Sacred to Life** – John Daido Loori on art and practice
+  📘 [The Monastery Store](https://monasterystore.org/products/bringing-the-sacred-to-life)
 
-- **Opening the Hand of Thought** – Kōshō Uchiyama on zazen  
-  📘 [Wisdom Publications](https://wisdomexperience.org/product/opening-the-hand-of-thought/)
+- **Opening the Hand of Thought** – Kōshō Uchiyama on zazen
+  📘 [The Monastery Store](https://monasterystore.org/products/opening-the-hand-of-thought)
 
 ---
 

--- a/pages/recipes.md
+++ b/pages/recipes.md
@@ -23,7 +23,7 @@ Mindful cooking is a form of practice—an expression of care, creativity, and c
 
 #### 🧅 Townsend’s Baked Onion (Erik's Favorite Recipe)
 
-<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/xV9spqCzSkQ?si=OZ6D-HInhvndyH_p" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/xV9spqCzSkQ?si=VfVrKMJUt0g9OpRI" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 
 #### 📺 Full Playlist: SOTOZENNET Shojin Cooking
 

--- a/pages/video-and-film.md
+++ b/pages/video-and-film.md
@@ -30,16 +30,16 @@ Tip: If the embedded video isn't working, try clearing your cookies and cache.
     <iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/H2Gz1ikHruQ?si=S1CUYdQzL0g4dcsP" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 </div>
 
-- [*Spring, Summer, Fall, Winter... and Spring*](https://www.youtube.com/watch?v=3rIgudJbHek)
+- [*Spring, Summer, Fall, Winter... and Spring*](https://www.youtube.com/watch?v=2Jd-n2cFrvM)
 
 <div style="position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden; max-width: 100%;">
-  <iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/3rIgudJbHek?si=DTVbkwAffmPEt9RN" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+  <iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/2Jd-n2cFrvM?si=KX7Y0VnD7_-0lGAP" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 </div>
 
-- [*Zen* (2009)](https://www.amazon.com/Zen-English-Subtitled-Kantaro-Nakamura/dp/B00B4YH9ZK)
+- [*Zen* (2009)](https://www.imdb.com/title/tt1265998/)
 
 <div style="position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden; max-width: 100%;">
-  <iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/A7eAEZyfJHg" title="Zen (2009) Full Movie" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+  <iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/pwKXTj1IQUc?si=2V5uGbsuYh6AoYty" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 </div>
 
 - [*One Mind*](https://vimeo.com/ondemand/onemindfilm)
@@ -51,7 +51,7 @@ Tip: If the embedded video isn't working, try clearing your cookies and cache.
 - [*Why Has Bodhi-Dharma Left for the East?*](https://www.kanopy.com/product/why-has-bodhi-dharma-left-east)
 
 <div style="position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden; max-width: 100%;">
-  <iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/-qpE6PnzgZY" title="Why Has Bodhi-Dharma Left for the East? Trailer" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+  <iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/IBKeCVjFPdY?si=a7ay4QduQkHEZIf1" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 </div>
 
 - [*Amongst White Clouds*](https://www.amazon.com/Amongst-Clouds-Chinese-Buddhist-hermit/dp/B000S76VHQ)
@@ -75,7 +75,7 @@ Tip: If the embedded video isn't working, try clearing your cookies and cache.
 - [*The Mountain Path*](https://www.amazon.com/Mountain-Buddhist-Hermits-Zhongnan-Mountains/dp/B0B8TJTGT5)
 
 <div style="position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden; max-width: 100%;">
-  <iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/fU71rpL1RFM" title="The Mountain Path Trailer" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+  <iframe width="560" height="315" src="https://www.youtube.com/embed/JmoYQ5nHgCo?si=tVRm9Nb8IlQ9Ymrn" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 </div>
 
 - [*Rivers and Tides*](https://www.amazon.com/Rivers-Tides-Andy-Goldsworthy/dp/B0010XIGLG)
@@ -110,7 +110,7 @@ Tip: If the embedded video isn't working, try clearing your cookies and cache.
 
 ### Branching Streams Affiliate Channels
 
-Here are some YouTube channels from SFZC and its Branching Streams affiliate centers:
+Here are official channels or websites from SFZC and its Branching Streams affiliate centers:
 
 - [SOTOZENNET Channel](https://youtube.com/@sotozennet?si=pkMiWdy9nwIZVLNG)
   Official YouTube channel of Soto Zen International
@@ -118,16 +118,16 @@ Here are some YouTube channels from SFZC and its Branching Streams affiliate cen
 - [Akazienzendo (Berlin, Germany)](https://www.youtube.com/@AkazienzendoBerlin)
   Zen teachings and practice sessions from Berlin.
 
-- [Ancient Dragon Zen Gate (Chicago, IL)](https://www.youtube.com/@AncientDragonZenGate)
+- [Ancient Dragon Zen Gate (Chicago, IL)](https://www.ancientdragon.org/)
   Dharma talks and teachings from the Chicago-based sangha.
 
-- [Austin Zen Center](https://www.youtube.com/@AustinZenCenter)
+- [Austin Zen Center](https://austinzencenter.org/)
   Offers recorded talks and practice instructions.
 
-- [Berkeley Zen Center](https://www.youtube.com/@BerkeleyZenCenter)
+- [Berkeley Zen Center](https://www.youtube.com/channel/UC2UKL6vJNCB4c5DVkeK4C0w/playlists)
   Dharma talks and teachings from the Berkeley sangha.
 
-- [Black Mountain Zen Centre (Belfast, Northern Ireland)](https://www.youtube.com/@BlackMountainZenCentre)
+- [Black Mountain Zen Centre (Belfast, Northern Ireland)](https://bmzcbelfast.org/)
   Teachings and community events from the Belfast-based sangha.
 
 - [Brooklyn Zen Center](https://www.youtube.com/@BrooklynZenCenter)
@@ -136,19 +136,19 @@ Here are some YouTube channels from SFZC and its Branching Streams affiliate cen
 - [Centro Zen L'Arco (Rome, Italy)](https://www.youtube.com/@CentroZenLArco)
   Zen teachings and sessions from Rome.
 
-- [Chapel Hill Zen Center (Chapel Hill, NC)](https://www.youtube.com/@ChapelHillZenCenter)
+- [Chapel Hill Zen Center (Chapel Hill, NC)](https://www.chzc.org/)
   Offers recorded talks and practice sessions from the North Carolina community.
 
 - [City Center Dharma Talks – SFZC Playlist](https://www.youtube.com/playlist?list=PLCcQNCXygdxoQD_meyKG7rCimgyyj0Opp)
   A curated playlist of Dharma talks recorded at SFZC’s City Center.
 
-- [Hartford Street Zen Center](https://www.youtube.com/@HartfordStreetZenCenter)
+- [Hartford Street Zen Center](https://www.szba.org/hartford-street-zen-center)
   Teachings from the Issan-ji temple community in San Francisco.
 
 - [Houston Zen Center](https://www.youtube.com/@HoustonZenCenter)
   Features talks and community teachings from Gaelyn Godwin Roshi and others.
 
-- [Montaña Despierta (Xalapa, Mexico)](https://www.youtube.com/@MontanaDespierta)
+- [Montaña Despierta (Xalapa, Mexico)](https://mdzen.com/)
   Dharma talks and teachings from the Xalapa-based sangha.
 
 - [Ocean Gate Zen Center (Santa Cruz, CA)](https://www.youtube.com/@OceanGateZenCenter)
@@ -157,13 +157,13 @@ Here are some YouTube channels from SFZC and its Branching Streams affiliate cen
 - [San Francisco Zen Center (SFZC)](https://www.youtube.com/user/SFZenCenter)
   Offers Dharma talks, meditation sessions, and teachings from City Center, Green Gulch Farm, and Tassajara.
 
-- [Santa Cruz Zen Center](https://www.youtube.com/@SantaCruzZenCenter)
+- [Santa Cruz Zen Center](https://sczc.org/)
   A library of recorded Dharma talks and retreats.
 
-- [Vallejo Zen Center (Vallejo, CA)](https://www.youtube.com/@VallejoZenCenter)
+- [Vallejo Zen Center (Vallejo, CA)](https://www.vallejozencenter.org/)
   Shares Dharma talks and events from the Vallejo sangha.
 
-- [Zen Heart Sangha (San Francisco Peninsula, CA)](https://www.youtube.com/@ZenHeartSangha)
+- [Zen Heart Sangha (San Francisco Peninsula, CA)](https://www.zenheartsangha.org/)
   Dharma talks and practice guidance from the SF Peninsula community.
 
 ---


### PR DESCRIPTION
## Summary
- fix remaining broken links and embeds in video/film, liturgy, and recipes content pages
- add TESTING.md with explicit local render + lint/build verification steps
- update AGENTS.md to require TESTING.md as the testing source of truth
- update CHANGELOG.md for this batch of user-facing and policy updates

## Validation
- markdownlint "**/*.md": pass
- yamllint .: pass
- jq . renovate.json > /dev/null: pass
- bundle exec jekyll build: blocked in sandbox due DNS resolution to codeload.github.com
- yardstick -path . -format table: command not available in this environment