### PR TITLE
Bump pinned yardstick to v0.5.0

### DIFF
--- a/.github/workflows/yardstick.yml
+++ b/.github/workflows/yardstick.yml
@@ -14,10 +14,10 @@ jobs:
 
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.22.x"
+          go-version: "1.26.x"
 
       - name: Install pinned yardstick release
-        run: go install github.com/hittegit/yardstick@v0.4.0
+        run: go install github.com/hittegit/yardstick@v0.5.0
 
       - name: Run yardstick and save JSON report
         run: |


### PR DESCRIPTION
Closes #12

yardstick.yml was pinned to v0.4.0 with go-version 1.22.x, both stale since the yardstick v0.5.0 release bumped Go to 1.26.

## Changes
- go-version: 1.22.x → 1.26.x
- yardstick install pin: v0.4.0 → v0.5.0

Note: renovate.json already has a regexManager tracking the `go install github.com/hittegit/yardstick@vX.Y.Z` pin, so future yardstick releases should be picked up automatically going forward.